### PR TITLE
Update install steps to use /etc/apt/keyrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Acton tip releases are like nightlies but more up to date.
 
 Install Acton tip releases via this apt repository:
 ```sh
-wget -q -O - https://aptip.acton-lang.io/acton.gpg | sudo apt-key add -
-echo "deb http://aptip.acton-lang.io/ tip main" | sudo tee /etc/apt/sources.list.d/acton.list
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo wget -q -O /etc/apt/keyrings/acton.asc https://aptip.acton-lang.io/acton.gpg
+sudo chmod a+r /etc/apt/keyrings/acton.asc
+echo "deb [signed-by=/etc/apt/keyrings/acton.asc] http://aptip.acton-lang.io/ tip main" | sudo tee /etc/apt/sources.list.d/acton.list
 sudo apt-get update
 sudo apt-get install -qy acton
 ```


### PR DESCRIPTION
Use the key only for the acton package repository, not global.